### PR TITLE
fix: providers stuck in initializing state

### DIFF
--- a/src/react/context.tsx
+++ b/src/react/context.tsx
@@ -344,7 +344,7 @@ export function ShuttleProvider({
   // Initialize providers
   useEffect(() => {
     (extensionProviders ?? providers)
-      .filter((extensionProvider) => !extensionProvider.initializing && !extensionProvider.initialized)
+      .filter((extensionProvider) => extensionProvider.extensionProviderAdapter.isReady())
       .forEach((extensionProvider) => {
         extensionProvider
           .init()


### PR DESCRIPTION
Currently if a specific extension is not avaliable/installed providers get stuck in initializing state

Expected both `initializing` and `initialized` flags on providers to be false under those conditions