### PR TITLE
Add gas price fee currency overrides

### DIFF
--- a/packages/core/src/internals/adapters/extensions/Keplr.ts
+++ b/packages/core/src/internals/adapters/extensions/Keplr.ts
@@ -220,10 +220,16 @@ export class Keplr implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<SigningResult> {
     if (!this.keplr) {
@@ -259,10 +265,16 @@ export class Keplr implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<SigningResult> {
     if (!this.keplr) {
@@ -333,10 +345,16 @@ export class Keplr implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<BroadcastResult> {
     if (!this.keplr) {

--- a/packages/core/src/internals/adapters/extensions/Metamask.ts
+++ b/packages/core/src/internals/adapters/extensions/Metamask.ts
@@ -1,6 +1,6 @@
 import { getEthereumAddress, hexToBase64, hexToBuff, recoverTypedSignaturePubKey } from "@injectivelabs/sdk-ts";
 
-import type { Network } from "../../../internals/network";
+import type { Network, NetworkCurrency } from "../../../internals/network";
 import type { SigningResult, BroadcastResult } from "../../../internals/transactions";
 import type { TransactionMsg } from "../../../internals/transactions/messages";
 import type { WalletConnection } from "../../../internals/wallet";
@@ -98,10 +98,16 @@ export class Metamask implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<SigningResult> {
     if (!this.ethereum) {
@@ -158,10 +164,16 @@ export class Metamask implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<BroadcastResult> {
     if (!this.ethereum) {

--- a/packages/core/src/internals/adapters/extensions/MetamaskCosmosSnap.ts
+++ b/packages/core/src/internals/adapters/extensions/MetamaskCosmosSnap.ts
@@ -1,7 +1,7 @@
 import { Algo, AminoSignResponse } from "@cosmjs/amino";
 import { toBase64 } from "@cosmjs/encoding";
 
-import type { Network } from "../../network";
+import type { Network, NetworkCurrency } from "../../network";
 import type { SigningResult, BroadcastResult } from "../../transactions";
 import type { TransactionMsg } from "../../transactions/messages";
 import type { WalletConnection } from "../../wallet";
@@ -130,10 +130,16 @@ export class MetamaskCosmosSnap implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<SigningResult> {
     if (!this.ethereum) {
@@ -192,10 +198,16 @@ export class MetamaskCosmosSnap implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<BroadcastResult> {
     if (!this.ethereum) {

--- a/packages/core/src/internals/adapters/extensions/Station.ts
+++ b/packages/core/src/internals/adapters/extensions/Station.ts
@@ -1,7 +1,7 @@
 import { GasPrice } from "@cosmjs/stargate";
 import { fromBase64 } from "@cosmjs/encoding";
 
-import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE, type Network } from "../../../internals/network";
+import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE, NetworkCurrency, type Network } from "../../../internals/network";
 import type { SigningResult, BroadcastResult } from "../../../internals/transactions";
 import type { TransactionMsg } from "../../../internals/transactions/messages";
 import { Algos, type WalletConnection } from "../../../internals/wallet";
@@ -153,10 +153,16 @@ export class Station implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<SigningResult> {
     if (!this.extension) {
@@ -180,8 +186,9 @@ export class Station implements ExtensionProviderAdapter {
       }
     }
 
-    const feeCurrency = network.feeCurrencies?.[0] || network.defaultCurrency || DEFAULT_CURRENCY;
-    const gasPrice = GasPrice.fromString(network.gasPrice || DEFAULT_GAS_PRICE);
+    const feeCurrency =
+      overrides?.feeCurrency ?? network.feeCurrencies?.[0] ?? network.defaultCurrency ?? DEFAULT_CURRENCY;
+    const gasPrice = GasPrice.fromString(overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE);
     const gas = String(gasPrice.amount.toFloatApproximation() * 10 ** feeCurrency.coinDecimals);
     const fee = JSON.stringify({
       amount: [{ amount: feeAmount && feeAmount != "auto" ? feeAmount : gas, denom: feeCurrency.coinMinimalDenom }],
@@ -215,10 +222,16 @@ export class Station implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<BroadcastResult> {
     if (!this.extension) {
@@ -241,8 +254,9 @@ export class Station implements ExtensionProviderAdapter {
         /* empty */
       }
     }
-    const feeCurrency = network.feeCurrencies?.[0] || network.defaultCurrency || DEFAULT_CURRENCY;
-    const gasPrice = GasPrice.fromString(network.gasPrice || DEFAULT_GAS_PRICE);
+    const feeCurrency =
+      overrides?.feeCurrency ?? network.feeCurrencies?.[0] ?? network.defaultCurrency ?? DEFAULT_CURRENCY;
+    const gasPrice = GasPrice.fromString(overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE);
     const gas = String(gasPrice.amount.toFloatApproximation() * 10 ** feeCurrency.coinDecimals);
     const fee = JSON.stringify({
       amount: [{ amount: feeAmount && feeAmount != "auto" ? feeAmount : gas, denom: feeCurrency.coinMinimalDenom }],

--- a/packages/core/src/internals/adapters/extensions/Vectis.ts
+++ b/packages/core/src/internals/adapters/extensions/Vectis.ts
@@ -191,10 +191,16 @@ export class Vectis implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<SigningResult> {
     if (!this.vectis) {
@@ -226,10 +232,16 @@ export class Vectis implements ExtensionProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
     },
   ): Promise<BroadcastResult> {
     if (!this.vectis) {

--- a/packages/core/src/internals/adapters/extensions/index.ts
+++ b/packages/core/src/internals/adapters/extensions/index.ts
@@ -1,4 +1,4 @@
-import type { Network } from "../../../internals/network";
+import type { Network, NetworkCurrency } from "../../../internals/network";
 import type { BroadcastResult, SigningResult } from "../../../internals/transactions";
 import type { TransactionMsg } from "../../../internals/transactions/messages";
 import type { WalletConnection } from "../../../internals/wallet";
@@ -25,6 +25,8 @@ export interface ExtensionProviderAdapter {
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
     },
   ): Promise<SigningResult>;
@@ -41,6 +43,8 @@ export interface ExtensionProviderAdapter {
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
     },
   ): Promise<BroadcastResult>;

--- a/packages/core/src/internals/adapters/mobile/CosmosWalletConnect.ts
+++ b/packages/core/src/internals/adapters/mobile/CosmosWalletConnect.ts
@@ -2,7 +2,7 @@ import { AminoSignResponse } from "@cosmjs/amino";
 import SignClient from "@walletconnect/sign-client";
 
 import { isAndroid, isIOS, isMobile } from "../../../utils/device";
-import type { Network } from "../../../internals/network";
+import type { Network, NetworkCurrency } from "../../../internals/network";
 import { type WalletConnection, type Algo, Algos, WalletMobileSession } from "../../../internals/wallet";
 import type { WalletMobileProvider } from "../../../providers/mobile";
 import type { SigningResult } from "../../../internals/transactions";
@@ -191,10 +191,16 @@ export class CosmosWalletConnect implements MobileProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
       intents: { androidUrl: string; iosUrl: string };
     },
   ): Promise<SigningResult> {

--- a/packages/core/src/internals/adapters/mobile/EvmWalletConnect.ts
+++ b/packages/core/src/internals/adapters/mobile/EvmWalletConnect.ts
@@ -2,7 +2,7 @@ import SignClient from "@walletconnect/sign-client";
 import { getEthereumAddress, hexToBase64, hexToBuff, recoverTypedSignaturePubKey } from "@injectivelabs/sdk-ts";
 
 import { isAndroid, isIOS, isMobile } from "../../../utils/device";
-import type { Network } from "../../../internals/network";
+import type { Network, NetworkCurrency } from "../../../internals/network";
 import type { WalletConnection, WalletMobileSession } from "../../../internals/wallet";
 import { fromInjectiveCosmosChainToEthereumChain, isInjectiveNetwork } from "../../../internals/injective";
 import type { SigningResult } from "../../../internals/transactions";
@@ -213,10 +213,16 @@ export class EvmWalletConnect implements MobileProviderAdapter {
       network: Network;
       messages: TransactionMsg<any>[];
       wallet: WalletConnection;
-      feeAmount?: string | null | undefined;
-      gasLimit?: string | null | undefined;
-      memo?: string | null | undefined;
-      overrides?: { rpc?: string | undefined; rest?: string | undefined; gasAdjustment?: number } | undefined;
+      feeAmount?: string | null;
+      gasLimit?: string | null;
+      memo?: string | null;
+      overrides?: {
+        rpc?: string;
+        rest?: string;
+        gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
+      };
       intents: { androidUrl: string; iosUrl: string };
     },
   ): Promise<SigningResult> {

--- a/packages/core/src/internals/adapters/mobile/index.ts
+++ b/packages/core/src/internals/adapters/mobile/index.ts
@@ -1,4 +1,4 @@
-import type { Network } from "../../../internals/network";
+import type { Network, NetworkCurrency } from "../../../internals/network";
 import type { WalletConnection, WalletMobileSession } from "../../../internals/wallet";
 import type { SigningResult } from "../../../internals/transactions";
 import type { TransactionMsg } from "../../../internals/transactions/messages";
@@ -30,6 +30,8 @@ export interface MobileProviderAdapter {
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
       intents: { androidUrl: string; iosUrl: string };
     },

--- a/packages/core/src/internals/cosmos/AminoSigningClient.ts
+++ b/packages/core/src/internals/cosmos/AminoSigningClient.ts
@@ -11,7 +11,7 @@ import type { SigningResult } from "../../internals/transactions";
 import type { TransactionMsg } from "../../internals/transactions/messages";
 import type { WalletConnection } from "../../internals/wallet";
 import type { Coin, Fee } from "../../internals/cosmos";
-import type { Network } from "../../internals/network";
+import type { Network, NetworkCurrency } from "../../internals/network";
 import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE } from "../../internals/network";
 import { isInjectiveNetwork } from "../../internals/injective";
 
@@ -35,10 +35,13 @@ export class AminoSigningClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<StdSignDoc> {
-    const gasPrice = GasPrice.fromString(network.gasPrice || DEFAULT_GAS_PRICE);
-    const feeCurrency = network.feeCurrencies?.[0] || network.defaultCurrency || DEFAULT_CURRENCY;
+    const gasPrice = GasPrice.fromString(overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE);
+    const feeCurrency =
+      overrides?.feeCurrency ?? network.feeCurrencies?.[0] ?? network.defaultCurrency ?? DEFAULT_CURRENCY;
     const gas = String(gasPrice.amount.toFloatApproximation() * 10 ** feeCurrency.coinDecimals);
 
     let accountNumber = "";

--- a/packages/core/src/internals/cosmos/BroadcastClient.ts
+++ b/packages/core/src/internals/cosmos/BroadcastClient.ts
@@ -3,7 +3,7 @@ import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import { BroadcastMode, TxRestApi } from "@injectivelabs/sdk-ts";
 
 import { BroadcastResult, SigningResult } from "../../internals/transactions";
-import { Network } from "../../internals/network";
+import { Network, NetworkCurrency } from "../../internals/network";
 import { isInjectiveNetwork } from "../../internals/injective";
 
 export class BroadcastClient {
@@ -18,6 +18,8 @@ export class BroadcastClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<BroadcastResult> {
     if (isInjectiveNetwork(network.chainId)) {
@@ -38,6 +40,8 @@ export class BroadcastClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<BroadcastResult> {
     const client = await CosmWasmClient.connect(overrides?.rpc || network.rpc);
@@ -63,6 +67,8 @@ export class BroadcastClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<BroadcastResult> {
     const txRestApi = new TxRestApi(overrides?.rest || network.rest);

--- a/packages/core/src/internals/cosmos/InjectiveEIP712SigningClient.ts
+++ b/packages/core/src/internals/cosmos/InjectiveEIP712SigningClient.ts
@@ -17,7 +17,7 @@ import {
   fromInjectiveCosmosChainToEthereumChain,
   prepareMessagesForInjective,
 } from "../../internals/injective";
-import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE, type Network } from "../../internals/network";
+import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE, NetworkCurrency, type Network } from "../../internals/network";
 import type { WalletConnection } from "../../internals/wallet";
 import type { SigningResult } from "../../internals/transactions";
 import type { TransactionMsg } from "../../internals/transactions/messages";
@@ -45,14 +45,17 @@ export class InjectiveEIP712SigningClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<{
     messages: InjTransactionMsg[];
     eip712TypedData: Eip712TypedData;
     signDoc: StdSignDoc & { timeout_height: string };
   }> {
-    const gasPrice = GasPrice.fromString(network.gasPrice || DEFAULT_GAS_PRICE);
-    const feeCurrency = network.feeCurrencies?.[0] || network.defaultCurrency || DEFAULT_CURRENCY;
+    const gasPrice = GasPrice.fromString(overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE);
+    const feeCurrency =
+      overrides?.feeCurrency ?? network.feeCurrencies?.[0] ?? network.defaultCurrency ?? DEFAULT_CURRENCY;
     const gas = String(gasPrice.amount.toFloatApproximation() * 10 ** feeCurrency.coinDecimals);
 
     let fee: Fee = {

--- a/packages/core/src/internals/cosmos/SignAndBroadcastClient.ts
+++ b/packages/core/src/internals/cosmos/SignAndBroadcastClient.ts
@@ -3,7 +3,7 @@ import { GasPrice } from "@cosmjs/stargate";
 
 import { type BroadcastResult } from "../../internals/transactions";
 import type { TransactionMsg } from "../../internals/transactions/messages";
-import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE, type Network } from "../../internals/network";
+import { DEFAULT_CURRENCY, DEFAULT_GAS_PRICE, NetworkCurrency, type Network } from "../../internals/network";
 import type { WalletConnection } from "../../internals/wallet";
 import type { Fee } from "../../internals/cosmos";
 import { extendedRegistryTypes } from "../registry";
@@ -31,10 +31,12 @@ export class SignAndBroadcastClient {
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
     },
   ): Promise<BroadcastResult> {
-    const gasPrice = GasPrice.fromString(network.gasPrice || DEFAULT_GAS_PRICE);
+    const gasPrice = GasPrice.fromString(overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE);
     const client = await SigningCosmWasmClient.connectWithSigner(overrides?.rpc || network.rpc, offlineSigner, {
       gasPrice,
     });
@@ -46,7 +48,8 @@ export class SignAndBroadcastClient {
 
     let fee: "auto" | Fee = "auto";
     if (feeAmount && feeAmount != "auto") {
-      const feeCurrency = network.feeCurrencies?.[0] || network.defaultCurrency || DEFAULT_CURRENCY;
+      const feeCurrency =
+        overrides?.feeCurrency ?? network.feeCurrencies?.[0] ?? network.defaultCurrency ?? DEFAULT_CURRENCY;
       const gas = String(gasPrice.amount.toFloatApproximation() * 10 ** feeCurrency.coinDecimals);
       fee = {
         amount: [{ amount: feeAmount || gas, denom: feeCurrency.coinMinimalDenom }],

--- a/packages/core/src/internals/cosmos/SimulateClient.ts
+++ b/packages/core/src/internals/cosmos/SimulateClient.ts
@@ -1,7 +1,7 @@
 import { calculateFee, GasPrice } from "@cosmjs/stargate";
 import { BaseAccount, ChainRestAuthApi, createTransactionAndCosmosSignDoc, TxRestApi } from "@injectivelabs/sdk-ts";
 
-import { DEFAULT_GAS_MULTIPLIER, DEFAULT_GAS_PRICE, Network } from "../../internals/network";
+import { DEFAULT_GAS_MULTIPLIER, DEFAULT_GAS_PRICE, Network, NetworkCurrency } from "../../internals/network";
 import { WalletConnection } from "../../internals/wallet";
 import { SimulateResult, TransactionMsg } from "../../internals/transactions";
 import { isInjectiveNetwork, prepareMessagesForInjective } from "../../internals/injective";
@@ -24,6 +24,8 @@ export class SimulateClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<SimulateResult> {
     if (isInjectiveNetwork(network.chainId)) {
@@ -46,10 +48,12 @@ export class SimulateClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<SimulateResult> {
     const signer = new FakeOfflineSigner(wallet);
-    const gasPrice = GasPrice.fromString(network.gasPrice || DEFAULT_GAS_PRICE);
+    const gasPrice = GasPrice.fromString(overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE);
     const client = await SigningCosmWasmClient.connectWithSigner(overrides?.rpc ?? network.rpc, signer, {
       gasPrice,
     });
@@ -64,7 +68,7 @@ export class SimulateClient {
 
       const fee = calculateFee(
         Math.round(gasEstimation * (overrides?.gasAdjustment ?? DEFAULT_GAS_MULTIPLIER)),
-        network.gasPrice || DEFAULT_GAS_PRICE,
+        overrides?.gasPrice ?? network.gasPrice ?? DEFAULT_GAS_PRICE,
       ) as Fee;
 
       return {
@@ -92,6 +96,8 @@ export class SimulateClient {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<SimulateResult> {
     const chainRestAuthApi = new ChainRestAuthApi(overrides?.rest ?? network.rest);

--- a/packages/core/src/internals/cosmos/SimulateClient.ts
+++ b/packages/core/src/internals/cosmos/SimulateClient.ts
@@ -123,7 +123,7 @@ export class SimulateClient {
         Math.round(
           (txClientSimulateResponse.gasInfo?.gasUsed || 0) * (overrides?.gasAdjustment ?? DEFAULT_GAS_MULTIPLIER),
         ),
-        network.gasPrice || "0.0005inj",
+        overrides?.gasPrice ?? network.gasPrice ?? "0.0005inj",
       ) as Fee;
 
       return {

--- a/packages/core/src/providers/extensions/WalletExtensionProvider.ts
+++ b/packages/core/src/providers/extensions/WalletExtensionProvider.ts
@@ -1,7 +1,7 @@
 import type { BroadcastResult, SigningResult, SimulateResult } from "../../internals/transactions";
 import type { TransactionMsg } from "../../internals/transactions/messages";
 import type { ExtensionProviderAdapter } from "../../internals/adapters";
-import type { Network } from "../../internals/network";
+import type { Network, NetworkCurrency } from "../../internals/network";
 import type { WalletConnection } from "../../internals/wallet";
 import SimulateClient from "../../internals/cosmos/SimulateClient";
 
@@ -91,6 +91,8 @@ export abstract class WalletExtensionProvider {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<SimulateResult> {
     if (!this.extensionProviderAdapter.isReady()) {
@@ -134,6 +136,8 @@ export abstract class WalletExtensionProvider {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<SigningResult> {
     if (!this.extensionProviderAdapter.isReady()) {
@@ -180,6 +184,8 @@ export abstract class WalletExtensionProvider {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<BroadcastResult> {
     if (!this.extensionProviderAdapter.isReady()) {

--- a/packages/core/src/providers/mobile/WalletMobileProvider.ts
+++ b/packages/core/src/providers/mobile/WalletMobileProvider.ts
@@ -1,6 +1,6 @@
 import type { MobileProviderAdapter } from "../../internals/adapters/mobile";
 import type { TransactionMsg, BroadcastResult, SigningResult, SimulateResult } from "../../internals/transactions";
-import type { Network } from "../../internals/network";
+import type { Network, NetworkCurrency } from "../../internals/network";
 import type { MobileConnectResponse } from "../../internals/providers";
 import type { WalletConnection, WalletMobileSession } from "../../internals/wallet";
 import SimulateClient from "../../internals/cosmos/SimulateClient";
@@ -176,6 +176,8 @@ export abstract class WalletMobileProvider {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<SigningResult> {
     if (!this.mobileProviderAdapter.isReady()) {
@@ -230,6 +232,8 @@ export abstract class WalletMobileProvider {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }): Promise<BroadcastResult> {
     if (!this.mobileProviderAdapter.isReady()) {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -12,6 +12,7 @@ import {
   SimulateResult,
   BroadcastResult,
   SigningResult,
+  NetworkCurrency,
 } from "@delphi-labs/shuttle";
 
 import { ShuttleStore, useShuttleStore } from "./store";
@@ -37,6 +38,8 @@ export type ShuttleContextType = {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }) => Promise<SimulateResult>;
   broadcast: (options: {
@@ -49,6 +52,8 @@ export type ShuttleContextType = {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }) => Promise<BroadcastResult>;
   sign: (options: {
@@ -61,6 +66,8 @@ export type ShuttleContextType = {
       rpc?: string;
       rest?: string;
       gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }) => Promise<SigningResult>;
   signArbitrary: (options: { wallet?: WalletConnection | null; data: Uint8Array }) => Promise<SigningResult>;
@@ -225,6 +232,8 @@ export function ShuttleProvider({
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
     }) => {
       const walletToUse = wallet || recentWallet;
@@ -260,6 +269,8 @@ export function ShuttleProvider({
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
     }) => {
       const walletToUse = wallet || recentWallet;
@@ -295,6 +306,8 @@ export function ShuttleProvider({
         rpc?: string;
         rest?: string;
         gasAdjustment?: number;
+        gasPrice?: string;
+        feeCurrency?: NetworkCurrency;
       };
     }) => {
       const walletToUse = wallet || recentWallet;

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -3,6 +3,7 @@ import { Pinia } from "pinia";
 import {
   BroadcastResult,
   MobileConnectResponse,
+  NetworkCurrency,
   SigningResult,
   SimulateResult,
   TransactionMsg,
@@ -47,6 +48,9 @@ export type Shuttle = {
     overrides?: {
       rpc?: string;
       rest?: string;
+      gasAdjustment?: number;
+      gasPrice?: string;
+      feeCurrency?: NetworkCurrency;
     };
   }) => Promise<BroadcastResult>;
   sign: (options: {
@@ -169,6 +173,8 @@ export function createShuttle({
             rpc?: string;
             rest?: string;
             gasAdjustment?: number;
+            gasPrice?: string;
+            feeCurrency?: NetworkCurrency;
           };
         }) => {
           const walletToUse = wallet || store.recentWallet;
@@ -204,6 +210,8 @@ export function createShuttle({
             rpc?: string;
             rest?: string;
             gasAdjustment?: number;
+            gasPrice?: string;
+            feeCurrency?: NetworkCurrency;
           };
         }) => {
           const walletToUse = wallet || store.recentWallet;
@@ -239,6 +247,8 @@ export function createShuttle({
             rpc?: string;
             rest?: string;
             gasAdjustment?: number;
+            gasPrice?: string;
+            feeCurrency?: NetworkCurrency;
           };
         }) => {
           const walletToUse = wallet || store.recentWallet;


### PR DESCRIPTION
With the addition of dynamic gas prices, with the skip fee markets module, we now need to add the ability to override gas price.